### PR TITLE
fixed for new stats since 4.1 kernel

### DIFF
--- a/zram
+++ b/zram
@@ -2,3 +2,7 @@
 # of system RAM to allocate to ZRAM block devices
 # Too big, and your system will start killing off processes
 FACTOR=33
+
+# Compression method listed in /sys/block/zram0/comp_algorithm
+# Set to empty to stay with default
+COMP_ALG=lzo

--- a/zramstart
+++ b/zramstart
@@ -15,7 +15,9 @@ mem_by_cpu=$(($memtotal/$num_cpus*$factor/100*1024))
 modprobe -q zram num_devices=$num_cpus
 
 for i in $(seq 0 $last_cpu); do
+	[ -z $COMP_ALG ] || echo $COMP_ALG > /sys/block/zram$i/comp_algorithm    
         echo $mem_by_cpu > /sys/block/zram$i/disksize
+	
         mkswap /dev/zram$i
         swapon -p 100 /dev/zram$i
 done

--- a/zramstat
+++ b/zramstat
@@ -3,8 +3,7 @@
 ls /sys/block/zram* > /dev/null 2>&1 || exit 0
 
 for i in /sys/block/zram*; do
-	compr=$(< $i/compr_data_size)
-	orig=$(< $i/orig_data_size)
+	read orig compr rest < $i/mm_stat
 	ratio=0
 	if [ $compr -gt 0 ]; then
 		ratio=$(echo "scale=2; $orig*100/$compr" | bc -q)

--- a/zramstat
+++ b/zramstat
@@ -3,7 +3,8 @@
 ls /sys/block/zram* > /dev/null 2>&1 || exit 0
 
 for i in /sys/block/zram*; do
-	read orig compr rest < $i/mm_stat
+	compr=$(< $i/compr_data_size)
+	orig=$(< $i/orig_data_size)
 	ratio=0
 	if [ $compr -gt 0 ]; then
 		ratio=$(echo "scale=2; $orig*100/$compr" | bc -q)


### PR DESCRIPTION
The way stats are exported has changed as described here: https://lwn.net/Articles/636124/

Adapted zramstat